### PR TITLE
Fix for S4S, M4M CS:GO Bug Caused by Valve

### DIFF
--- a/addons/sourcemod/scripting/hosties/lastrequest.sp
+++ b/addons/sourcemod/scripting/hosties/lastrequest.sp
@@ -1115,7 +1115,7 @@ public LastRequest_PlayerHurt(Handle:event, const String:name[], bool:dontBroadc
 			{
 				decl String:weapon[32];
 				GetEventString(event, "weapon", weapon, 32);
-				new bool:bIsItAKnife = StrEqual(weapon, "knife");
+				new bool:bIsItAKnife = (StrContains(FiredWeapon, "knife") == -1 ? false : true);
 				
 				switch (type)
 				{
@@ -1646,11 +1646,11 @@ public LastRequest_WeaponFire(Handle:event, const String:name[], bool:dontBroadc
 					// set the time to enable burst value to a high value
 					SetEntDataFloat(iClientWeapon, g_Offset_SecAttack, 5000.0);
 					
-					if (iClientWeapon != M4M_Prisoner_Weapon && iClientWeapon != M4M_Guard_Weapon && !StrEqual(FiredWeapon, "knife"))
+					if (iClientWeapon != M4M_Prisoner_Weapon && iClientWeapon != M4M_Guard_Weapon && StrContains(FiredWeapon, "knife") == -1)
 					{
 						DecideRebelsFate(client, idx, -1);
 					}
-					else if (!StrEqual(FiredWeapon, "knife"))
+					else if (StrContains(FiredWeapon, "knife") == -1)
 					{
 						new currentAmmo = GetEntData(iClientWeapon, g_Offset_Clip1);
 						// check if a shot was actually fired
@@ -1775,7 +1775,11 @@ public LastRequest_WeaponFire(Handle:event, const String:name[], bool:dontBroadc
 					if (iClientWeapon != -1)
 					{
 						GetEdictClassname(iClientWeapon, LR_WeaponName, sizeof(LR_WeaponName));
-						ReplaceString(LR_WeaponName, sizeof(LR_WeaponName), "weapon_", "");
+						// as of 8 December 2015 CS:GO weapon_fire events need weapon_ to remain
+						if (g_Game == Game_CSS)
+						{
+							ReplaceString(LR_WeaponName, sizeof(LR_WeaponName), "weapon_", "");
+						}
 					}
 					
 					if (StrEqual(LR_WeaponName, FiredWeapon))
@@ -1842,7 +1846,7 @@ public LastRequest_WeaponFire(Handle:event, const String:name[], bool:dontBroadc
 							}
 						}		    							
 					}
-					else if (!StrEqual(FiredWeapon, "knife"))
+					else if (StrContains(FiredWeapon, "knife") == -1)
 					{
 						DecideRebelsFate(client, idx, -1);
 					}

--- a/addons/sourcemod/scripting/hosties/lastrequest.sp
+++ b/addons/sourcemod/scripting/hosties/lastrequest.sp
@@ -1764,22 +1764,20 @@ public LastRequest_WeaponFire(Handle:event, const String:name[], bool:dontBroadc
 					new Guard_S4S_Pistol = GetArrayCell(gH_DArray_LR_Partners, idx, _:Block_GuardData);
 					new S4Slastshot = GetArrayCell(gH_DArray_LR_Partners, idx, _:Block_Global1);
 					
-					decl String:FiredWeapon[32];
+					decl String:FiredWeapon[48];
 					GetEventString(event, "weapon", FiredWeapon, sizeof(FiredWeapon));
+					// as of 8 December 2015 CS:GO weapon_fire events need weapon_ to remain
+					ReplaceString(FiredWeapon, sizeof(FiredWeapon), "weapon_", "");
 					
 					// get the entity index of the pistol
 					new iClientWeapon = GetPlayerWeaponSlot(client, CS_SLOT_SECONDARY);
 					
 					// check if we have the same weapon
-					new String:LR_WeaponName[32];
+					new String:LR_WeaponName[48];
 					if (iClientWeapon != -1)
 					{
 						GetEdictClassname(iClientWeapon, LR_WeaponName, sizeof(LR_WeaponName));
-						// as of 8 December 2015 CS:GO weapon_fire events need weapon_ to remain
-						if (g_Game == Game_CSS)
-						{
-							ReplaceString(LR_WeaponName, sizeof(LR_WeaponName), "weapon_", "");
-						}
+						ReplaceString(LR_WeaponName, sizeof(LR_WeaponName), "weapon_", "");
 					}
 					
 					if (StrEqual(LR_WeaponName, FiredWeapon))

--- a/addons/sourcemod/scripting/hosties/lastrequest.sp
+++ b/addons/sourcemod/scripting/hosties/lastrequest.sp
@@ -1115,7 +1115,7 @@ public LastRequest_PlayerHurt(Handle:event, const String:name[], bool:dontBroadc
 			{
 				decl String:weapon[32];
 				GetEventString(event, "weapon", weapon, 32);
-				new bool:bIsItAKnife = (StrContains(FiredWeapon, "knife") == -1 ? false : true);
+				new bool:bIsItAKnife = (StrContains(weapon, "knife") == -1 ? false : true);
 				
 				switch (type)
 				{


### PR DESCRIPTION
Valve changed the weapon_fire event string "weapon" to contain "weapon_" in the string unlike CS:S where it was omitted.  This caused a break for S4S and M4M LRs.  A switch to StrContains and a game based check were added as a solution.