### PR TITLE
Move GameType enum to lastrequest.inc

### DIFF
--- a/addons/sourcemod/scripting/include/hosties.inc
+++ b/addons/sourcemod/scripting/include/hosties.inc
@@ -27,13 +27,6 @@
 #define 	CHAT_BANNER			"\x03[SM] \x04%t"
 #define 	NORMAL_VISION		90
 
-enum GameType
-{
-	Game_Unknown = -1,
-	Game_CSS,
-	Game_CSGO
-};
-
 enum FreekillPunishment
 {
 	FP_Slay = 0,

--- a/addons/sourcemod/scripting/include/lastrequest.inc
+++ b/addons/sourcemod/scripting/include/lastrequest.inc
@@ -24,6 +24,13 @@
 #define _LastRequest_Included_
 
 // Custom types
+enum GameType
+{
+	Game_Unknown = -1,
+	Game_CSS,
+	Game_CSGO
+};
+
 enum LastRequest
 {
 	LR_KnifeFight = 0,


### PR DESCRIPTION
Hosties.inc appears to just be stocks for sm_hosties to work.
Lastrequest.inc is where the natives are and is meant to be included with other plugins.
Lastrequest.inc requires this enum to compile, if its in Hosties.inc then Hosties.inc needs to be included aswell which i believe is bad practice as it creates bloat.

Some plugins will actually fail to compile using a clone of the github master as they (correctly) do not include hosties.inc, and only include lastrequest.inc.
The error given will be something along the lines of undefined symbol game_unknown.