### PR TITLE
Add sm1.10 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,14 @@ addons:
     - lftp
 
 env:
-  - SOURCEMOD=1.7
   - SOURCEMOD=1.8
   - SOURCEMOD=1.9
+  - SOURCEMOD=1.10
 
 matrix:
   fast_finish: true
   allow_failures:
-    - env: SMVERSION=1.9
+    - env: SMVERSION=1.10
 
 script:
   - bash build.sh $SOURCEMOD $B_FTP_HOST $B_FTP_USER $B_FTP_PASS 


### PR DESCRIPTION
Remove sm1.7 (it's now longer the "current" stable, that's now [sm1.8](http://www.sourcemod.net/downloads.php?branch=stable))
We shouldn't allow failures on sm1.9 (will be the new stable version)