### PR TITLE
Fix SourceMod 1.10 Builds

### DIFF
--- a/addons/sourcemod/scripting/include/lastrequest.inc
+++ b/addons/sourcemod/scripting/include/lastrequest.inc
@@ -104,9 +104,8 @@ public __pl_lastrequest_SetNTVOptional()
 	MarkNativeAsOptional("CleanupLR");
 }
 
-functag FuncLastRequest public(type, prisoner, guard);
-functag FuncProcessLR public(Handle:array, iLRNumber);
-
+typedef FuncLastRequest = function void(int type, int prisoner, int guard);
+typedef FuncProcessLR = function void(Handle array, int iLRNumber);
 
 forward OnStartLR(PrisonerIndex, GuardIndex, LR_Type);
 


### PR DESCRIPTION
`functag` was deprecated in 1.10