### PR TITLE
Replace deprecated functags to allow compilation with spcomp 1.10

### DIFF
--- a/addons/sourcemod/scripting/include/lastrequest.inc
+++ b/addons/sourcemod/scripting/include/lastrequest.inc
@@ -104,8 +104,8 @@ public __pl_lastrequest_SetNTVOptional()
 	MarkNativeAsOptional("CleanupLR");
 }
 
-functag FuncLastRequest public(type, prisoner, guard);
-functag FuncProcessLR public(Handle:array, iLRNumber);
+typedef FuncLastRequest = function void (int type, int prisoner, int guard);
+typedef FuncProcessLR = function void (Handle array, int iLRNumber);
 
 
 forward OnStartLR(PrisonerIndex, GuardIndex, LR_Type);


### PR DESCRIPTION
Example error:
C:\Games\SteamDev\CSGO\Plugins\include\lastrequest.inc(109) : fatal error 196: deprecated syntax; see https://wiki.alliedmods.net/SourcePawn_Transitional_Syntax#Typedefs